### PR TITLE
Expose fd in Socket to allow non-blocking operations

### DIFF
--- a/toolbelt/sockets.h
+++ b/toolbelt/sockets.h
@@ -126,6 +126,8 @@ public:
     is_nonblocking_ = true;
     return absl::OkStatus();
   }
+  // Get the fd on which to poll for non-blocking operations.
+  FileDescriptor GetFileDescriptor() const { return fd_; }
 
   bool IsNonBlocking() const { return is_nonblocking_; }
   bool IsBlocking() const { return !is_nonblocking_; }


### PR DESCRIPTION
Expose fd in Socket to allow non-blocking operations. The socket classes allow the user to set them to non-blocking, but without access to the file-descriptor, it's not clear to me how the user is supposed to be able to tell when the socket is ready for recv/send.