### PR TITLE
Fixed gcc c++17 error about field order in aggregate init

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,13 +27,14 @@ http_archive(
   name = "com_google_googletest",
   urls = ["https://github.com/google/googletest/archive/5ab508a01f9eb089207ee87fd547d290da39d015.zip"],
   strip_prefix = "googletest-5ab508a01f9eb089207ee87fd547d290da39d015",
+  sha256 = "755f9a39bc7205f5a0c428e920ddad092c33c8a1b46997def3f1d4a82aded6e1",
 )
 
 http_archive(
   name = "coroutines",
-  urls = ["https://github.com/dallison/cocpp/archive/refs/tags/1.2.4.tar.gz"],
-  strip_prefix = "cocpp-1.2.4",
-  sha256 = "b5c877cef99c93d47c7fe52c800ac1629854e31ac5141016f0161d72db59461e"
+  urls = ["https://github.com/dallison/co/archive/refs/tags/1.3.3.tar.gz"],
+  strip_prefix = "co-1.3.3",
+  sha256 = "5c152150ee06213ae2c0af83609d2c5baacb621f857c69dd77c41f0fc453ae32"
 )
 
 

--- a/toolbelt/table.cc
+++ b/toolbelt/table.cc
@@ -35,7 +35,7 @@ void Table::AddRow(const std::vector<std::string> cells, Color color) {
     if (index >= cols_.size()) {
       break;
     }
-    AddCell(index, {.color = color, .data = cell});
+    AddCell(index, {.data = cell, .color = color});
     index++;
   }
   ++num_rows_;


### PR DESCRIPTION
Fixed gcc c++17 error about field order in aggregate init

Apparently, GCC doesn't like that the order of field initialization is not the same as the declaration order. See error below. This PR fixes that.

I also updated the version and sha's on the dependencies, bazel was erroring on that too. It might be related to the recent Bazel 7 update that breaks a lot of stuff it seems.

GCC error:

```
toolbelt/table.cc: In member function 'void toolbelt::Table::AddRow(std::vector<std::__cxx11::basic_string<char> >, toolbelt::Table::Color)':
toolbelt/table.cc:38:12: error: designator order for field 'toolbelt::Table::Cell::data' does not match declaration order in 'const toolbelt::Table::Cell'
   38 |     AddCell(index, {.color = color, .data = cell});
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```