### PR TITLE
Added triggered info to Clear

### DIFF
--- a/toolbelt/triggerfd.h
+++ b/toolbelt/triggerfd.h
@@ -51,7 +51,10 @@ class TriggerFd {
   void SetTriggerFd(FileDescriptor fd) { trigger_fd_ = std::move(fd); }
 
   void Trigger();
-  void Clear();
+
+  // Clears the trigger and simultaneously checks if it was triggered.
+  // Returns true if the triggerfd had been triggered prior to entering this function. 
+  bool Clear();
 
   FileDescriptor &GetPollFd() { return poll_fd_; }
   FileDescriptor &GetTriggerFd() { return trigger_fd_; }


### PR DESCRIPTION
I thought this would be useful, it would be to me. This commit adds a bool return to the TriggerFd::Clear function to tell the caller whether the trigger was triggered (and now, cleared) or if it was not triggered (and thus, the clear just read nothing, just got EAGAIN). The reason why this is useful is because I'm using a TriggerFd as one of many Fds in a poll call, but this particular event is high priority, so I want to check it more often than just whenever I get around to it looking at all the other events ready in the pollfd set. I guess that I could poll the fd alone with a zero timeout too (not sure if that is entirely portable), but I figured that just clearing it and getting back the confirmation that it was triggered would be a more atomic.

Thinking about that, although I don't think you intend to support users having multiple threads polling on the same TriggerFd, in theory, if people did that, it would be a racy without this feature. With multiple consumers waking from the poll, they'll need an atomic clear-and-check (aka CAS) to clear it and confirm that they should do whatever the trigger is supposed to cause them to do. Without that, you'd get a random number of consumers reacting to a single trigger. (explaining all this more for posterity, since you understand all this stuff much better than me ;) )

Anyways, this seems like a pretty simple change. An alternative would be a "probe" function to check if the fd is readable without clearing it, but that wouldn't fix the potential race condition.