### PR TITLE
Fixed bug with fd reset followed by destruction after close

### DIFF
--- a/toolbelt/fd.cc
+++ b/toolbelt/fd.cc
@@ -7,7 +7,7 @@ void CloseAllFds(std::function<bool(int)> predicate) {
   struct rlimit lim;
   int e = getrlimit(RLIMIT_NOFILE, &lim);
   if (e == 0) {
-    for (int fd = 0; fd < lim.rlim_cur; fd++) {
+    for (int fd = 0; fd < static_cast<int>(lim.rlim_cur); fd++) {
       if (fcntl(fd, F_GETFD) == 0 && predicate(fd) ) {
         (void)close(fd);
       }

--- a/toolbelt/fd.h
+++ b/toolbelt/fd.h
@@ -201,8 +201,8 @@ private:
     assert(data_->ref > 0);
     if (--data_->ref == 0) {
       delete data_;
-      data_ = nullptr;
     }
+    data_ = nullptr;
   }
 
   void IncRef() {

--- a/toolbelt/fd_test.cc
+++ b/toolbelt/fd_test.cc
@@ -155,3 +155,22 @@ TEST(FdTest, Release) {
   int e = fstat(f, &st);
   ASSERT_EQ(0, e);
 }
+
+TEST(FdTest, Reset) {
+  int f = dup(1);
+  {
+    // Take ownership of f.
+    FileDescriptor fd1(f);
+
+    FileDescriptor fd2(fd1);
+
+    // Reset ownership of f by fd1 before destruction.
+    fd1.Reset();
+  } // If fd1 was correctly reset, this could assert-fail.
+
+  // f will be closed.
+  struct stat st;
+  int e = fstat(f, &st);
+  ASSERT_EQ(-1, e);
+}
+

--- a/toolbelt/sockets.cc
+++ b/toolbelt/sockets.cc
@@ -549,9 +549,9 @@ absl::Status UDPSocket::SendTo(const InetAddress &addr, const void *buffer,
   if (c != nullptr) {
     c->Wait(fd_.Fd(), POLLOUT);
   }
-  size_t n = ::sendto(fd_.Fd(), buffer, length, 0,
-                      reinterpret_cast<const sockaddr *>(&addr.GetAddress()),
-                      addr.GetLength());
+  ssize_t n = ::sendto(fd_.Fd(), buffer, length, 0,
+                       reinterpret_cast<const sockaddr *>(&addr.GetAddress()),
+                       addr.GetLength());
   if (n == -1) {
     return absl::InternalError(
         absl::StrFormat("Unable to send UDP datagram to %s: %s",
@@ -565,7 +565,7 @@ absl::StatusOr<ssize_t> UDPSocket::Receive(void *buffer, size_t buflen,
   if (c != nullptr) {
     c->Wait(fd_.Fd(), POLLIN);
   }
-  size_t n = recv(fd_.Fd(), buffer, buflen, 0);
+  ssize_t n = recv(fd_.Fd(), buffer, buflen, 0);
   if (n == -1) {
     return absl::InternalError(
         absl::StrFormat("Unable to receive UDP datagram: %s", strerror(errno)));
@@ -581,9 +581,9 @@ absl::StatusOr<ssize_t> UDPSocket::ReceiveFrom(InetAddress &sender,
   struct sockaddr_in sender_addr;
   socklen_t sender_addr_length = sizeof(sender_addr);
 
-  size_t n = recvfrom(fd_.Fd(), buffer, buflen, 0,
-                      reinterpret_cast<struct sockaddr *>(&sender_addr),
-                      &sender_addr_length);
+  ssize_t n = recvfrom(fd_.Fd(), buffer, buflen, 0,
+                       reinterpret_cast<struct sockaddr *>(&sender_addr),
+                       &sender_addr_length);
   if (n == -1) {
     return absl::InternalError(
         absl::StrFormat("Unable to receive UDP datagram: %s", strerror(errno)));


### PR DESCRIPTION
Fixed bug with fd reset followed by destruction after close

The new unit test shows the issue. That test will cause the `assert(data_->ref > 0);` to fail if an Fd is closed or reset manually when there is a greater than 1 ref-count, and later it is destroyed after the fd has been closed. The issue is that the data_ pointer was set to null only if the ref count went to zero, but that is wrong, whether the data_ is deleted or not, the Fd object has to set data_ to nullptr since it is no longer linked to that shared data.

The workaround I found in the mean time was to do `fd = FileDescriptor{};` instead of calling Close or Reset. That works because the move assignment operator sets the data_ to nullptr (from the moved-in default-constructed Fd).

This MR also includes a couple of trivial changes to quiet yet some more warnings. Notably though, the "n" values were "size_t" instead of "ssize_t", which obviously makes an important difference, potentially.