### PR TITLE
Fixed explicit specialization inside class scope, not supported by GCC

### DIFF
--- a/toolbelt/payload_buffer.h
+++ b/toolbelt/payload_buffer.h
@@ -164,12 +164,6 @@ struct PayloadBuffer {
     return SetString(self, s.data(), s.size(), header_offset);
   }
 
-  template <>
-  char *SetString(PayloadBuffer **self, const char *s,
-                  BufferOffset header_offset) {
-    return SetString(self, s, strlen(s), header_offset);
-  }
-
   static void ClearString(PayloadBuffer **self, BufferOffset header_offset);
 
   static absl::Span<char> AllocateString(PayloadBuffer **self, size_t len,
@@ -346,6 +340,13 @@ struct PayloadBuffer {
     }
   }
 };
+
+
+template <>
+char *PayloadBuffer::SetString(PayloadBuffer **self, const char *s,
+                BufferOffset header_offset) {
+  return SetString(self, s, strlen(s), header_offset);
+}
 
 template <typename T> inline void PayloadBuffer::Set(BufferOffset offset, T v) {
   T *addr = ToAddress<T>(offset);

--- a/toolbelt/payload_buffer_test.cc
+++ b/toolbelt/payload_buffer_test.cc
@@ -234,7 +234,7 @@ TEST(BufferTest, Resizeable) {
   char *buffer = (char *)malloc(256);
   bool resized = false;
   PayloadBuffer *pb = new (buffer)
-      PayloadBuffer(256, [&resized](PayloadBuffer **p, size_t new_size) {
+      PayloadBuffer(256, [&resized](PayloadBuffer **p, size_t old_size, size_t new_size) {
         std::cout << "resize for " << new_size << std::endl;
         *p = reinterpret_cast<PayloadBuffer *>(realloc(*p, new_size));
         resized = true;


### PR DESCRIPTION
Fixed explicit specialization inside class scope, not supported by GCC. Just another accommodation for the "differently-abled" compiler.

Also, the test was not up-to-date.