### PR TITLE
Adding multicast support

### DIFF
--- a/toolbelt/BUILD.bazel
+++ b/toolbelt/BUILD.bazel
@@ -78,6 +78,19 @@ cc_test(
 )
 
 cc_test(
+    name = "sockets_test",
+    size = "small",
+    srcs = ["sockets_test.cc"],
+    deps = [
+        ":toolbelt",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "payload_buffer_test",
     srcs = [
         "payload_buffer_test.cc",
@@ -87,5 +100,3 @@ cc_test(
         ":toolbelt",
     ],
 )
-
-

--- a/toolbelt/sockets.cc
+++ b/toolbelt/sockets.cc
@@ -6,6 +6,7 @@
 
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -553,7 +554,7 @@ absl::StatusOr<TCPSocket> TCPSocket::Accept(co::Coroutine *c) {
 }
 
 // UDP socket
-UDPSocket::UDPSocket() : NetworkSocket(socket(AF_INET, SOCK_DGRAM, 0)) {}
+UDPSocket::UDPSocket() : NetworkSocket(socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) {}
 
 absl::Status UDPSocket::Bind(const InetAddress &addr) {
   int e =
@@ -565,8 +566,62 @@ absl::Status UDPSocket::Bind(const InetAddress &addr) {
         absl::StrFormat("Failed to bind UDP socket to %s: %s",
                         addr.ToString().c_str(), strerror(errno)));
   }
+
   bound_address_ = addr;
+
+  if (addr.Port() == 0) {
+    // An ephemeral port was request, find out what the assigned port is
+    sockaddr_in address;
+    socklen_t address_size = sizeof(address);
+    if (getsockname(fd_.Fd(), reinterpret_cast<sockaddr *>(&address), &address_size) != 0) {
+        return absl::InternalError(
+            absl::StrFormat("Failed to get ephemeral port assignment for %s: %s",
+                addr.ToString().c_str(), strerror(errno)));
+    }
+    bound_address_.SetPort(ntohs(address.sin_port));
+  }
+
   connected_ = true; // UDP sockets are always connected when bound.
+  return absl::OkStatus();
+}
+
+absl::Status UDPSocket::JoinMulticastGroup(const InetAddress &addr) {
+    ip_mreqn membership_request {
+        .imr_multiaddr = addr.GetAddress().sin_addr,
+        .imr_address = {INADDR_ANY},
+        .imr_ifindex = {0}
+    };
+    int setsockopt_ret = ::setsockopt(fd_.Fd(),
+                                     IPPROTO_IP,
+                                     IP_ADD_MEMBERSHIP,
+                                     &membership_request,
+                                     sizeof(membership_request));
+    if (setsockopt_ret != 0) {
+        fd_.Reset();
+        return absl::InternalError(
+            absl::StrFormat("Failed to join multicast group %s: %s",
+                           addr.ToString().c_str(), strerror(errno)));
+    }
+    return absl::OkStatus();
+}
+
+absl::Status UDPSocket::LeaveMulticastGroup(const InetAddress &addr) {
+  ip_mreqn membership_request {
+    .imr_multiaddr = addr.GetAddress().sin_addr,
+    .imr_address = { INADDR_ANY },
+    .imr_ifindex = { 0 }
+  };
+  int setsockopt_ret = ::setsockopt(fd_.Fd(),
+                                    IPPROTO_IP,
+                                    IP_DROP_MEMBERSHIP,
+                                    &membership_request,
+                                    sizeof(membership_request));
+  if (setsockopt_ret != 0) {
+    fd_.Reset();
+    return absl::InternalError(
+        absl::StrFormat("Failed to join multicast group %s: %s",
+                        addr.ToString().c_str(), strerror(errno)));
+  }
   return absl::OkStatus();
 }
 
@@ -576,6 +631,15 @@ absl::Status UDPSocket::SetBroadcast() {
   if (e != 0) {
     return absl::InternalError(absl::StrFormat(
         "Unable to set broadcast on UDP socket: %s", strerror(errno)));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status UDPSocket::SetMulticastLoop() {
+  constexpr int enable = 1;
+  if (setsockopt(fd_.Fd(), IPPROTO_IP, IP_MULTICAST_LOOP, &enable, sizeof(enable)) != 0) {
+      return absl::InternalError(absl::StrFormat(
+          "Unable to set multicast loop on UDP socket: %s", strerror(errno)));
   }
   return absl::OkStatus();
 }

--- a/toolbelt/sockets.h
+++ b/toolbelt/sockets.h
@@ -116,7 +116,7 @@ public:
 
   absl::StatusOr<std::vector<char>> ReceiveVariableLengthMessage(
       co::Coroutine *c = nullptr);
-      
+
   // For SendMessage, the buffer pointer must be 4 bytes beyond
   // the actual buffer start, which must be length+4 bytes
   // long.  We write exactly length+4 bytes to the socket starting
@@ -208,6 +208,9 @@ public:
 
   absl::Status Bind(const InetAddress &addr);
 
+  absl::Status JoinMulticastGroup(const InetAddress &addr);
+  absl::Status LeaveMulticastGroup(const InetAddress &addr);
+
   // NOTE: Read and Write may or may not work on UDP sockets.  Use SendTo and
   // Receive for datagrams.
   absl::Status SendTo(const InetAddress &addr, const void *buffer,
@@ -218,6 +221,7 @@ public:
                                       size_t buflen,
                                       co::Coroutine *c = nullptr);
   absl::Status SetBroadcast();
+  absl::Status SetMulticastLoop();
 };
 
 // A TCP based socket.

--- a/toolbelt/sockets_test.cc
+++ b/toolbelt/sockets_test.cc
@@ -1,0 +1,109 @@
+#include "sockets.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string_view>
+#include <vector>
+
+namespace {
+constexpr std::string_view TEST_DATA = "The quick brown fox jumped over the lazy dog.";
+const static absl::Duration LOOPBACK_TIMEOUT = absl::Milliseconds(10);
+
+// Test class to hold on to a randomly assigned unused port until destruction
+// Any tests binding to this unused port will probably need to call NetworkSocket::SetReusePort
+class UnusedPort {
+public:
+  UnusedPort() {
+    static_cast<void>(socket.SetReusePort());
+    static_cast<void>(socket.Bind(toolbelt::InetAddress::AnyAddress(0)));
+  }
+  ~UnusedPort() = default;
+  operator int() {
+      return socket.BoundAddress().Port();
+  }
+
+private:
+  UnusedPort(const UnusedPort& copy) = delete;
+  UnusedPort(UnusedPort&& move) = delete;
+  void operator=(const UnusedPort& copy) = delete;
+  void operator=(UnusedPort&& move) = delete;
+  toolbelt::UDPSocket socket;
+};
+}
+
+TEST(SocketsTest, UDPSocket_SendAndReceiveUnicast) {
+  UnusedPort port;
+  auto sender = toolbelt::UDPSocket();
+  auto receiver = toolbelt::UDPSocket();
+
+  ASSERT_TRUE(receiver.SetReusePort().ok());
+  ASSERT_TRUE(receiver.Bind(toolbelt::InetAddress("localhost", port)).ok());
+
+  toolbelt::InetAddress sendto_address("localhost", port);
+  ASSERT_TRUE(sender.SendTo(sendto_address, TEST_DATA.data(), TEST_DATA.size()).ok());
+
+  std::vector<char> receive_buffer(TEST_DATA.size());
+  ASSERT_EQ(*receiver.Receive(receive_buffer.data(), receive_buffer.size()), TEST_DATA.size());
+  ASSERT_EQ(std::string_view(receive_buffer.data(), receive_buffer.size()), TEST_DATA);
+
+  ASSERT_EQ(0, std::strcmp(receive_buffer.data(), TEST_DATA.data()));
+}
+
+TEST(SocketsTest, UDPSocket_SendAndReceiveBroadcast) {
+  UnusedPort port;
+  auto sender = toolbelt::UDPSocket();
+  auto receiver = toolbelt::UDPSocket();
+
+  ASSERT_TRUE(sender.SetBroadcast().ok());
+
+  ASSERT_TRUE(receiver.SetReusePort().ok());
+  ASSERT_TRUE(receiver.Bind(toolbelt::InetAddress(toolbelt::InetAddress::AnyAddress(port))).ok());
+
+  toolbelt::InetAddress sendto_address(toolbelt::InetAddress::BroadcastAddress(port));
+  ASSERT_TRUE(sender.SendTo(sendto_address, TEST_DATA.data(), TEST_DATA.size()).ok());
+
+  std::vector<char> receive_buffer(TEST_DATA.size());
+  ASSERT_EQ(*receiver.Receive(receive_buffer.data(), receive_buffer.size()), TEST_DATA.size());
+  ASSERT_EQ(std::string_view(receive_buffer.data(), receive_buffer.size()), TEST_DATA);
+
+  ASSERT_EQ(0, std::strcmp(receive_buffer.data(), TEST_DATA.data()));
+}
+
+TEST(SocketsTest, UDPSocket_SendAndReceiveMulticast) {
+    UnusedPort port;
+    std::string multicast_ip = "224.0.0.205";
+    toolbelt::InetAddress multicast_address(multicast_ip, port);
+
+    auto sender = toolbelt::UDPSocket();
+    auto receiver = toolbelt::UDPSocket();
+
+    ASSERT_TRUE(sender.SetMulticastLoop().ok());
+
+    std::vector<char> receive_buffer(TEST_DATA.size());
+    ASSERT_TRUE(receiver.SetReusePort().ok());
+    ASSERT_TRUE(receiver.SetNonBlocking().ok());
+    ASSERT_TRUE(receiver.Bind(toolbelt::InetAddress::AnyAddress(port)).ok());
+
+    ASSERT_TRUE(receiver.JoinMulticastGroup(multicast_address).ok());
+    ASSERT_TRUE(sender.SendTo(multicast_address, TEST_DATA.data(), TEST_DATA.size()).ok());
+
+    absl::Time timeout = absl::Now() + LOOPBACK_TIMEOUT;
+    while (absl::Now() < timeout) {
+        auto status_or_len = receiver.Receive(receive_buffer.data(), receive_buffer.size());
+        if (status_or_len.ok()) {
+            ASSERT_EQ(*status_or_len, TEST_DATA.size());
+            ASSERT_EQ(std::string_view(receive_buffer.data(), receive_buffer.size()), TEST_DATA);
+            break;
+        }
+    }
+
+    ASSERT_TRUE(receiver.LeaveMulticastGroup(multicast_address).ok());
+    ASSERT_TRUE(sender.SendTo(multicast_address, TEST_DATA.data(), TEST_DATA.size()).ok());
+    timeout = absl::Now() + LOOPBACK_TIMEOUT;
+    while (absl::Now() < timeout) {
+        auto status_or_len = receiver.Receive(receive_buffer.data(), receive_buffer.size());
+        if (status_or_len.ok()) {
+            FAIL() << "Received " << *status_or_len << " bytes but expected nothing";
+        }
+    }
+}


### PR DESCRIPTION
Couple of questions:
- I implemented the special case for binding against port `0` for the `UDPSocket` and realised that nearly the same thing exists for `TCPSocket`. Do you want those consolidated in `NetworkSocket` (and have the `listen` logic special cased in `TCPSocket`)?
- Do you have a preferred `.clang-format` or something that I can run the new changes against?