### PR TITLE
Support/exclude older vm-sockets kernel implementations

### DIFF
--- a/toolbelt/sockets.cc
+++ b/toolbelt/sockets.cc
@@ -121,7 +121,7 @@ VirtualAddress VirtualAddress::AnyAddress(uint32_t port) {
   return VirtualAddress(VMADDR_CID_ANY, port);
 }
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(VMADDR_CID_LOCAL)
 VirtualAddress VirtualAddress::LocalAddress(uint32_t port) {
   return VirtualAddress(VMADDR_CID_LOCAL, port);
 }

--- a/toolbelt/sockets.h
+++ b/toolbelt/sockets.h
@@ -125,7 +125,7 @@ public:
   static VirtualAddress HypervisorAddress(uint32_t port);
   static VirtualAddress HostAddress(uint32_t port);
   static VirtualAddress AnyAddress(uint32_t port);
-#if defined(__linux__)
+#if defined(__linux__) && defined(VMADDR_CID_LOCAL)
   static VirtualAddress LocalAddress(uint32_t port);
 #endif
 


### PR DESCRIPTION
Support/exclude older vm-sockets kernel implementations

Running on some older kernels (<5.6, I think) means that local vm-sockets are not supported. This PR just adds that exclusion for the local virtual address.