### PR TITLE
Allow for older systems with no VM sockets header files.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -96,8 +96,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
-    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -179,7 +179,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
+        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/toolbelt/sockets.h
+++ b/toolbelt/sockets.h
@@ -17,9 +17,35 @@
 #include <sys/un.h>
 
 #if defined(__linux__)
+
+#if __has_include(<linux/vm_sockets.h>)
 #include <linux/vm_sockets.h>
+#define HAS_VM_SOCKETS 1
 #else
+#define HAS_VM_SOCKETS 0
+#endif
+
+#else
+#if __has_include(<sys/vsock.h>)
 #include <sys/vsock.h>
+#define HAS_VM_SOCKETS 1
+#else
+#define HAS_VM_SOCKETS 0
+#endif
+#endif
+
+// Older systems may not have the header file.
+#if !HAS_VM_SOCKETS
+struct sockaddr_vm {
+#if defined(_APPLE__)
+  uint8_t svm_len;      /* total length of sockaddr */
+#endif
+  sa_family_t svm_family; /* AF_VSOCK */
+  uint32_t svm_reserved1;
+  uint32_t svm_port;
+  uint32_t svm_cid;
+  uint32_t svm_reserved2;
+};
 #endif
 
 #include <unistd.h>

--- a/toolbelt/sockets.h
+++ b/toolbelt/sockets.h
@@ -46,6 +46,7 @@ struct sockaddr_vm {
   uint32_t svm_cid;
   uint32_t svm_reserved2;
 };
+#define VMADDR_CID_ANY (~0U)
 #endif
 
 #include <unistd.h>

--- a/toolbelt/sockets.h
+++ b/toolbelt/sockets.h
@@ -47,6 +47,10 @@ struct sockaddr_vm {
   uint32_t svm_reserved2;
 };
 #define VMADDR_CID_ANY (~0U)
+#define VMADDR_CID_HOST 1
+#define VMADDR_CID_HYPERVISOR 2
+#define VMADDR_CID_LOCAL 3
+#define AF_VSOCK 40
 #endif
 
 #include <unistd.h>


### PR DESCRIPTION
Was getting unknown header file for `#include <linux/vm_sockets.h>`. Handles this.